### PR TITLE
Math geo lib collisions

### DIFF
--- a/DrunkEngine/Bullet/include/BulletCollision/CollisionDispatch/btCollisionObject.h
+++ b/DrunkEngine/Bullet/include/BulletCollision/CollisionDispatch/btCollisionObject.h
@@ -16,7 +16,7 @@ subject to the following restrictions:
 #ifndef BT_COLLISION_OBJECT_H
 #define BT_COLLISION_OBJECT_H
 
-#include "LinearMath/btTransform.h"
+#include "../../LinearMath/btTransform.h"
 
 //island management, m_activationState1
 #define ACTIVE_TAG 1
@@ -28,9 +28,10 @@ subject to the following restrictions:
 struct	btBroadphaseProxy;
 class	btCollisionShape;
 struct btCollisionShapeData;
-#include "LinearMath/btMotionState.h"
-#include "LinearMath/btAlignedAllocator.h"
-#include "LinearMath/btAlignedObjectArray.h"
+
+#include "../../LinearMath/btMotionState.h"
+#include "../../LinearMath/btAlignedAllocator.h"
+#include "../../LinearMath/btAlignedObjectArray.h"
 
 typedef btAlignedObjectArray<class btCollisionObject*> btCollisionObjectArray;
 

--- a/DrunkEngine/DrunkEngine.vcxproj
+++ b/DrunkEngine/DrunkEngine.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{746CC4C3-787F-4B0E-AA66-E388FE3FF4F6}</ProjectGuid>
     <RootNamespace>SDLGame</RootNamespace>
     <ProjectName>DrunkEngine</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/DrunkEngine/Game/imgui.ini
+++ b/DrunkEngine/Game/imgui.ini
@@ -74,12 +74,12 @@ Size=402,234
 Collapsed=0
 
 [Window][Create Objects]
-Pos=66,40
+Pos=83,14
 Size=458,188
 Collapsed=0
 
 [Window][OpenGL Settings]
-Pos=78,427
+Pos=78,429
 Size=573,80
 Collapsed=0
 

--- a/DrunkEngine/Game/imgui.ini
+++ b/DrunkEngine/Game/imgui.ini
@@ -74,12 +74,12 @@ Size=402,234
 Collapsed=0
 
 [Window][Create Objects]
-Pos=125,272
+Pos=66,40
 Size=458,188
 Collapsed=0
 
 [Window][OpenGL Settings]
-Pos=155,307
+Pos=78,427
 Size=573,80
 Collapsed=0
 

--- a/DrunkEngine/Game/imgui.ini
+++ b/DrunkEngine/Game/imgui.ini
@@ -74,7 +74,7 @@ Size=402,234
 Collapsed=0
 
 [Window][Create Objects]
-Pos=257,6
+Pos=280,10
 Size=458,188
 Collapsed=0
 

--- a/DrunkEngine/Game/imgui.ini
+++ b/DrunkEngine/Game/imgui.ini
@@ -74,7 +74,7 @@ Size=402,234
 Collapsed=0
 
 [Window][Create Objects]
-Pos=212,363
+Pos=125,272
 Size=458,188
 Collapsed=0
 

--- a/DrunkEngine/Game/imgui.ini
+++ b/DrunkEngine/Game/imgui.ini
@@ -74,12 +74,12 @@ Size=402,234
 Collapsed=0
 
 [Window][Create Objects]
-Pos=83,14
+Pos=257,6
 Size=458,188
 Collapsed=0
 
 [Window][OpenGL Settings]
-Pos=78,429
+Pos=35,472
 Size=573,80
 Collapsed=0
 

--- a/DrunkEngine/GeometryCreationWindow.cpp
+++ b/DrunkEngine/GeometryCreationWindow.cpp
@@ -17,19 +17,27 @@ void GEOMWindow::Draw()
 		ImGui::Separator();
 
 		ImGui::Text("Sphere");
-		ImGui::SliderFloat3("Center", &sphere_center[0], 0, 10);
-		ImGui::SliderFloat("Radius", &sphere_radius, 0, 10);
-		ImGui::Checkbox("PhysObj", &sphere_phys);
+		ImGui::SliderFloat3("Sphere Center", &sphere_center[0], 0, 10);
+		ImGui::SliderFloat("Sphere Radius", &sphere_radius, 0, 10);
+		ImGui::Checkbox("Sphere PhysObj", &sphere_phys);
 		ImGui::SameLine();
-		if(ImGui::Button("Create"))
+		if(ImGui::Button("Create Sphere"))
 		{
-			if (sphere_phys)
-				App->physics->AddBody(sphere_center, PSphere(sphere_radius));
-			else
-				App->physics->AddSphereMath(sphere_center, sphere_radius);
+			App->physics->AddBody(sphere_center, PSphere(sphere_radius), sphere_phys);
 		}
 
 		ImGui::Separator();
+
+		ImGui::Text("Cube");
+		ImGui::SliderFloat3("Cube Center", &box_center[0], 0, 10);
+		ImGui::SliderFloat("Cube Size", &box_size, 0, 10);
+		ImGui::Checkbox("Cube PhysObj", &box_phys);
+		ImGui::SameLine();
+		if (ImGui::Button("Create Cube"))
+		{
+			App->physics->AddBody(box_center, PCube(box_size), box_phys);
+		}
+
 	}
 	ImGui::End();
 }

--- a/DrunkEngine/GeometryCreationWindow.h
+++ b/DrunkEngine/GeometryCreationWindow.h
@@ -17,6 +17,11 @@ public:
 	vec sphere_center;
 	float sphere_radius;
 	bool sphere_phys = false;
+
+	// Cube (AABB)
+	vec box_center;
+	float box_size;
+	bool box_phys = false;
 };
 
 #endif

--- a/DrunkEngine/ModuleCamera3D.cpp
+++ b/DrunkEngine/ModuleCamera3D.cpp
@@ -81,18 +81,7 @@ update_status ModuleCamera3D::Update(float dt)
 		if(dx != 0)
 		{
 			float DeltaX = (float)dx * Sensitivity;
-			
-			/*Quat qX = { X.x,X.y,X.z,1.0f };
-			Quat qY = { Y.x,Y.y,Y.z,1.0f };
-			Quat qZ = { Z.x,Z.y,Z.z,1.0f };
-
-			qX.RotateY(DeltaX);
-			qY.RotateY(DeltaX);
-			qZ.RotateY(DeltaX);
-
-			X = { qX.x, qX.y, qX.z };
-			Y = { qY.x, qY.y, qY.z };
-			Z = { qZ.x, qZ.y, qZ.z };*/
+		
 			X = rotate(X, DeltaX, vec3(0.0f, 1.0f, 0.0f));
 			Y = rotate(Y, DeltaX, vec3(0.0f, 1.0f, 0.0f));
 			Z = rotate(Z, DeltaX, vec3(0.0f, 1.0f, 0.0f));
@@ -102,21 +91,6 @@ update_status ModuleCamera3D::Update(float dt)
 		if(dy != 0)
 		{
 			float DeltaY = (float)dy * Sensitivity;
-
-			/*Quat qY = { Y.x,Y.y,Y.z,1.0f };
-			Quat qZ = { Z.x,Z.y,Z.z,1.0f };
-
-			qY.RotateY(DeltaY);
-			qZ.RotateY(DeltaY);
-
-			Y = { qY.x, qY.y, qY.z };
-			Z = { qZ.x, qZ.y, qZ.z };
-
-			if(Y.y < 0.0f)
-			{
-				Z = vec(0.0f, Z.y > 0.0f ? 1.0f : -1.0f, 0.0f);
-				Y = Z.Cross(X);
-			*/
 
 			Y = rotate(Y, DeltaY, X);
 			Z = rotate(Z, DeltaY, X);
@@ -129,7 +103,7 @@ update_status ModuleCamera3D::Update(float dt)
 
 		}
 
-		Position = Reference + Z * length(Position);//Position.Length();//length(btQuaternion(Position.x, Position.y,));
+		Position = Reference + Z * length(Position);
 	}
 
 	// Recalculate matrix -------------
@@ -143,21 +117,6 @@ void ModuleCamera3D::Look(const vec3 &Position, const vec3 &Reference, bool Rota
 {
 	this->Position = Position;
 	this->Reference = Reference;
-
-	/*
-	vec aux_z = Position - Reference;
-	Z = aux_z.Normalized();
-
-	vec aux_x = vec(0.0f, 1.0f, 0.0f).Cross(Z);
-	X = aux_x.Normalized();
-
-	Y = Z.Cross(X);
-
-	if(!RotateAroundReference)
-	{
-		this->Reference = this->Position;
-		this->Position += Z * 0.05f;
-	}*/
 
 	this->Position = Position;
 	this->Reference = Reference;
@@ -181,16 +140,6 @@ void ModuleCamera3D::LookAt( const vec3 &Spot)
 {
 	Reference = Spot;
 
-	/*
-	vec aux_z = Position - Reference;
-	Z = aux_z.Normalized();
-
-	vec aux_x = vec(0.0f, 1.0f, 0.0f).Cross(Z);
-	X = aux_x.Normalized();
-
-	Y = Z.Cross(X);
-	*/
-
 	Z = normalize(Position - Reference);
 	X = normalize(cross(vec3(0.0f, 1.0f, 0.0f), Z));
 	Y = cross(Z, X);
@@ -211,16 +160,12 @@ void ModuleCamera3D::Move(const vec3 &Movement)
 // -----------------------------------------------------------------
 float* ModuleCamera3D::GetViewMatrix()
 {
-	//ViewMatrix.Transpose();
 	return (float*)ViewMatrix.v;
 }
 
 // -----------------------------------------------------------------
 void ModuleCamera3D::CalculateViewMatrix()
 {
-
-	//ViewMatrix = float4x4(X.x, Y.x, Z.x, 0.0f, X.y, Y.y, Z.y, 0.0f, X.z, Y.z, Z.z, 0.0f, -X.Dot(Position), -Y.Dot(Position), -Z.Dot(Position), 1.0f);
-
 	ViewMatrix = float4x4(X.x, Y.x, Z.x, 0.0f, X.y, Y.y, Z.y, 0.0f, X.z, Y.z, Z.z, 0.0f, -dot(X, Position), -dot(Y, Position), -dot(Z, Position), 1.0f);
 	
 	ViewMatrixInverse = ViewMatrix.Inverted();

--- a/DrunkEngine/ModulePhysics3D.cpp
+++ b/DrunkEngine/ModulePhysics3D.cpp
@@ -106,7 +106,8 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 		}
 	}
 
-	// MathGeoLib Collision Detection
+
+	// MathGeoLib Collision Detection + Transform Update from the physbody if there is any
 	std::list<PhysBody3D*>::iterator item_pb = bodies.begin();
 
 	while (item_pb != bodies.end() && bodies.size() > 0)
@@ -116,6 +117,8 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 			vec center = (vec)item_pb._Ptr->_Myval->body->getCenterOfMassPosition();
 				
 			item_pb._Ptr->_Myval->mbody->SetPos(center.x, center.y, center.z);
+
+			// Try somehow to setup the transform identical to the new transform
 		}
 			
 
@@ -132,52 +135,6 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 
 		item_pb++;
 	}
-
-
-	// Mathbody pos update in relation to physic body, old
-	/*std::list<PhysBody3D*>::iterator item = bodies.begin();
-	std::list<Sphere*>::iterator item_sphere = spheres.begin();
-	std::list<Capsule*>::iterator item_capsule = capsules.begin();
-	std::list<AABB*>::iterator item_AABB = cubes.begin();
-	std::list<OBB*>::iterator item_OBB = obbs.begin();
-	std::list<Plane*>::iterator item_plane = planes.begin();
-	std::list<Ray*>::iterator item_ray = rays.begin();
-	std::list<Triangle*>::iterator item_tri = tris.begin();
-
-	while (item != bodies.end() && bodies.size() > 0) {
-		if (item._Ptr->_Myval->body->getCollisionShape()->getShapeType() == SPHERE_SHAPE_PROXYTYPE && item_sphere != spheres.end() && spheres.size() > 0)
-		{
-			item_sphere._Ptr->_Myval->Translate(((vec)item._Ptr->_Myval->body->getCenterOfMassPosition() - item_sphere._Ptr->_Myval->Centroid()));
-			item_sphere++;
-		}
-		
-		else if (item._Ptr->_Myval->body->getCollisionShape()->getShapeType() == CAPSULE_SHAPE_PROXYTYPE && item_capsule != capsules.end() && capsules.size() > 0)
-		{
-			item_capsule._Ptr->_Myval->Translate(((vec)item._Ptr->_Myval->body->getCenterOfMassPosition() - item_capsule._Ptr->_Myval->Center()));
-			item_capsule++;
-		}
-
-		else if (item._Ptr->_Myval->body->getCollisionShape()->getShapeType() == BOX_SHAPE_PROXYTYPE && item_AABB != cubes.end() && cubes.size() > 0)
-		{
-			item_AABB._Ptr->_Myval->Translate(((vec)item._Ptr->_Myval->body->getCenterOfMassPosition() - item_AABB._Ptr->_Myval->Centroid()));
-			item_AABB++;
-		}
-
-		else if (item._Ptr->_Myval->body->getCollisionShape()->getShapeType() == TRIANGLE_SHAPE_PROXYTYPE && item_tri != tris.end() && tris.size() > 0)
-		{
-			item_tri._Ptr->_Myval->Translate(((vec)item._Ptr->_Myval->body->getCenterOfMassPosition() - item_capsule._Ptr->_Myval->Center()));
-			item_tri++;
-		}
-		// Do for all types
-
-		else if (item_OBB != obbs.end() && obbs.size() > 0)
-		{
-			item_OBB._Ptr->_Myval->Translate(((vec)item._Ptr->_Myval->body->getCenterOfMassPosition() - item_OBB._Ptr->_Myval->CenterPoint()));
-			item_OBB++;
-		}
-		item++;
-		
-	*/
 
 	return UPDATE_CONTINUE;
 }
@@ -292,6 +249,7 @@ PhysBody3D* ModulePhysics3D::AddBody(const vec& center, PCube& cube,bool phys, f
 {
 	
 	btRigidBody* body = nullptr;
+	PCube* new_cube = new PCube(cube);
 
 	if (phys) {
 		btCollisionShape* colShape = new btBoxShape(btVector3(cube.size.x*0.5f, cube.size.y*0.5f, cube.size.z*0.5f));
@@ -310,29 +268,27 @@ PhysBody3D* ModulePhysics3D::AddBody(const vec& center, PCube& cube,bool phys, f
 		btRigidBody::btRigidBodyConstructionInfo rbInfo(mass, myMotionState, colShape, localInertia);
 
 		body = new btRigidBody(rbInfo);
-		
+
 		// Add Mathematical Sphere
-		AddAABBMath((vec)body->getCenterOfMassPosition(), cube.size.x);
+		new_cube->MathBody = AddAABBMath((vec)body->getCenterOfMassPosition(), cube.size.x/2.0f);
 
 		world->addRigidBody(body);
-	}
-
-	PCube* new_cube = new PCube(cube);
+	}	
 
 	if (!phys) {
 		
 
 		if (cube.size.x >= cube.size.y && cube.size.x >= cube.size.z)
 		{
-			new_cube->MathBody = *AddAABBMath(center, cube.size.x);
+			new_cube->MathBody = AddAABBMath(center, cube.size.x/2.0f);
 		}
 		else if (cube.size.y >= cube.size.x && cube.size.y >= cube.size.z)
 		{
-			AddAABBMath(center, cube.size.y);
+			new_cube->MathBody = AddAABBMath(center, cube.size.y/2.0f);
 		}
 		else if (cube.size.z >= cube.size.x && cube.size.z >= cube.size.y)
 		{
-			AddAABBMath(center, cube.size.z);
+			new_cube->MathBody = AddAABBMath(center, cube.size.z/2.0f);
 		}
 	}
 

--- a/DrunkEngine/ModulePhysics3D.cpp
+++ b/DrunkEngine/ModulePhysics3D.cpp
@@ -73,6 +73,7 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 	
 	world->stepSimulation(dt, 15);
 	
+	// Bullet Collision detection
 	int numManifolds = world->getDispatcher()->getNumManifolds();
 	for(int i = 0; i<numManifolds; i++)
 	{
@@ -104,7 +105,27 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 			}
 		}
 	}
-	
+
+	// MathGeoLib Collision Detection
+	std::list<PhysBody3D*>::iterator item_pb = bodies.begin();
+
+	while (item_pb != bodies.end() && bodies.size() > 0)
+	{
+		std::list<PhysBody3D*>::iterator item_pb_2 = ++item_pb;
+		item_pb--;
+		while (item_pb_2 != bodies.end())
+		{
+			if (item_pb._Ptr->_Myval->mbody->Intersects(item_pb_2._Ptr->_Myval->mbody))
+			{
+				PLOG("Detected Collision!")
+			}
+			item_pb_2++;
+		}
+
+		item_pb++;
+	}
+
+
 	// Mathbody pos update in relation to physic body
 	std::list<PhysBody3D*>::iterator item = bodies.begin();
 	std::list<Sphere*>::iterator item_sphere = spheres.begin();
@@ -217,7 +238,7 @@ bool ModulePhysics3D::CleanUp()
 
 
 // ---------------------------------------------------------
-PhysBody3D* ModulePhysics3D::AddBody(const vec& center, const PSphere& sphere, float mass)
+PhysBody3D* ModulePhysics3D::AddBody(const vec& center, PSphere& sphere, float mass)
 {
 	btCollisionShape* colShape = new btSphereShape(sphere.radius);
 	shapes.push_back(colShape);
@@ -235,7 +256,8 @@ PhysBody3D* ModulePhysics3D::AddBody(const vec& center, const PSphere& sphere, f
 	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass, myMotionState, colShape, localInertia);
 
 	btRigidBody* body = new btRigidBody(rbInfo);
-	PhysBody3D* pbody = new PhysBody3D(body);
+	PSphere* new_sphere = new PSphere(sphere);
+	PhysBody3D* pbody = new PhysBody3D(body, new_sphere);
 
 	// Add Mathematical Sphere
 	AddSphereMath((vec)body->getCenterOfMassPosition(), sphere.radius);
@@ -248,7 +270,7 @@ PhysBody3D* ModulePhysics3D::AddBody(const vec& center, const PSphere& sphere, f
 
 
 // ---------------------------------------------------------
-PhysBody3D* ModulePhysics3D::AddBody(const PCube& cube, float mass)
+PhysBody3D* ModulePhysics3D::AddBody(PCube& cube, float mass)
 {
 	btCollisionShape* colShape = new btBoxShape(btVector3(cube.size.x*0.5f, cube.size.y*0.5f, cube.size.z*0.5f));
 	shapes.push_back(colShape);
@@ -265,7 +287,7 @@ PhysBody3D* ModulePhysics3D::AddBody(const PCube& cube, float mass)
 	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass, myMotionState, colShape, localInertia);
 
 	btRigidBody* body = new btRigidBody(rbInfo);
-	PhysBody3D* pbody = new PhysBody3D(body);
+	PhysBody3D* pbody = new PhysBody3D(body, &cube);
 
 	// Add Mathematical Sphere
 	AddAABBMath((vec)body->getCenterOfMassPosition(), cube.size.x);
@@ -277,7 +299,7 @@ PhysBody3D* ModulePhysics3D::AddBody(const PCube& cube, float mass)
 }
 
 // ---------------------------------------------------------
-PhysBody3D* ModulePhysics3D::AddBody(const PCylinder& cylinder, float mass)
+PhysBody3D* ModulePhysics3D::AddBody(PCylinder& cylinder, float mass)
 {
 	btCollisionShape* colShape = new btCylinderShapeX(btVector3(cylinder.height*0.5f, cylinder.radius, 0.0f));
 	shapes.push_back(colShape);
@@ -294,7 +316,7 @@ PhysBody3D* ModulePhysics3D::AddBody(const PCylinder& cylinder, float mass)
 	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass, myMotionState, colShape, localInertia);
 
 	btRigidBody* body = new btRigidBody(rbInfo);
-	PhysBody3D* pbody = new PhysBody3D(body);
+	PhysBody3D* pbody = new PhysBody3D(body, &cylinder);
 
 	world->addRigidBody(body);
 	bodies.push_back(pbody);

--- a/DrunkEngine/ModulePhysics3D.cpp
+++ b/DrunkEngine/ModulePhysics3D.cpp
@@ -115,7 +115,7 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 		{
 			vec center = (vec)item_pb._Ptr->_Myval->body->getCenterOfMassPosition();
 				
-			item_pb._Ptr->_Myval->mbody->SetPos(center.x, center.y, center.z);			
+			item_pb._Ptr->_Myval->mbody->SetPos(center.x, center.y, center.z);
 		}
 			
 
@@ -134,8 +134,8 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 	}
 
 
-	// Mathbody pos update in relation to physic body
-	std::list<PhysBody3D*>::iterator item = bodies.begin();
+	// Mathbody pos update in relation to physic body, old
+	/*std::list<PhysBody3D*>::iterator item = bodies.begin();
 	std::list<Sphere*>::iterator item_sphere = spheres.begin();
 	std::list<Capsule*>::iterator item_capsule = capsules.begin();
 	std::list<AABB*>::iterator item_AABB = cubes.begin();
@@ -144,7 +144,7 @@ update_status ModulePhysics3D::PreUpdate(float dt)
 	std::list<Ray*>::iterator item_ray = rays.begin();
 	std::list<Triangle*>::iterator item_tri = tris.begin();
 
-	/*while (item != bodies.end() && bodies.size() > 0) {
+	while (item != bodies.end() && bodies.size() > 0) {
 		if (item._Ptr->_Myval->body->getCollisionShape()->getShapeType() == SPHERE_SHAPE_PROXYTYPE && item_sphere != spheres.end() && spheres.size() > 0)
 		{
 			item_sphere._Ptr->_Myval->Translate(((vec)item._Ptr->_Myval->body->getCenterOfMassPosition() - item_sphere._Ptr->_Myval->Centroid()));
@@ -317,12 +317,14 @@ PhysBody3D* ModulePhysics3D::AddBody(const vec& center, PCube& cube,bool phys, f
 		world->addRigidBody(body);
 	}
 
+	PCube* new_cube = new PCube(cube);
+
 	if (!phys) {
 		
 
 		if (cube.size.x >= cube.size.y && cube.size.x >= cube.size.z)
 		{
-			AddAABBMath(center, cube.size.x);
+			new_cube->MathBody = *AddAABBMath(center, cube.size.x);
 		}
 		else if (cube.size.y >= cube.size.x && cube.size.y >= cube.size.z)
 		{
@@ -334,8 +336,7 @@ PhysBody3D* ModulePhysics3D::AddBody(const vec& center, PCube& cube,bool phys, f
 		}
 	}
 
-	PCube* new_cube = new PCube(cube);
-	new_cube->MathBody.
+	
 	PhysBody3D* pbody = new PhysBody3D(body, new_cube);
 	bodies.push_back(pbody);
 

--- a/DrunkEngine/ModulePhysics3D.h
+++ b/DrunkEngine/ModulePhysics3D.h
@@ -85,15 +85,17 @@ public:
 		Capsule* add = new Capsule(axis_segment, radius);
 		capsules.push_back(add);
 	}
-	void AddAABBMath(const vec& min_point, const vec& max_point)
+	AABB* AddAABBMath(const vec& min_point, const vec& max_point)
 	{
 		AABB* add = new AABB(min_point,max_point);
 		cubes.push_back(add);
+		return add;
 	}
-	void AddAABBMath(const vec& center, const float& radius)
+	AABB* AddAABBMath(const vec& center, const float& radius)
 	{
 		AABB* add = new AABB(Sphere(center, radius));
 		cubes.push_back(add);
+		return add;
 	}
 	void AddPlaneMath(const vec& point, const vec& normal)
 	{

--- a/DrunkEngine/ModulePhysics3D.h
+++ b/DrunkEngine/ModulePhysics3D.h
@@ -30,15 +30,16 @@ public:
 	update_status PostUpdate(float dt);
 	bool CleanUp();
 
-	PhysBody3D* AddBody(const vec& center, PSphere& sphere, float mass = 1.0f); // This creates a mathematical sphere and technically a renderable sphere (passed as the transform of a polyhedron)
-	PhysBody3D* AddBody(PCube& cube, float mass = 1.0f);
-	PhysBody3D* AddBody(PCylinder& cylinder, float mass = 1.0f);
+	PhysBody3D* AddBody(const vec& center, PSphere& sphere, bool phys = true, float mass = 1.0f); // This creates a mathematical sphere and technically a renderable sphere (passed as the transform of a polyhedron)
+	PhysBody3D* AddBody(const vec& center, PCube& cube, bool phys = true, float mass = 1.0f);
+	PhysBody3D* AddBody(PCylinder& cylinder, bool phys = true, float mass = 1.0f);
 
 	
 
 
 	//void AddConstraintP2P(PhysBody3D& bodyA, PhysBody3D& bodyB, const vec& anchorA, const vec& anchorB);
 	//void AddConstraintHinge(PhysBody3D& bodyA, PhysBody3D& bodyB, const vec& anchorA, const vec& anchorB, const vec& axisS, const vec& axisB, bool disable_collision = false);
+	std::list<PhysBody3D*> bodies;
 
 private:
 
@@ -53,7 +54,7 @@ private:
 	DebugDrawer*						debug_draw;
 
 	std::list<btCollisionShape*> shapes;
-	std::list<PhysBody3D*> bodies;
+
 	std::list<btDefaultMotionState*> motions;
 	std::list<btTypedConstraint*> constraints;
 

--- a/DrunkEngine/ModulePhysics3D.h
+++ b/DrunkEngine/ModulePhysics3D.h
@@ -30,9 +30,9 @@ public:
 	update_status PostUpdate(float dt);
 	bool CleanUp();
 
-	PhysBody3D* AddBody(const vec& center, const PSphere& sphere, float mass = 1.0f); // This creates a mathematical sphere and technically a renderable sphere (passed as the transform of a polyhedron)
-	PhysBody3D* AddBody(const PCube& cube, float mass = 1.0f);
-	PhysBody3D* AddBody(const PCylinder& cylinder, float mass = 1.0f);
+	PhysBody3D* AddBody(const vec& center, PSphere& sphere, float mass = 1.0f); // This creates a mathematical sphere and technically a renderable sphere (passed as the transform of a polyhedron)
+	PhysBody3D* AddBody(PCube& cube, float mass = 1.0f);
+	PhysBody3D* AddBody(PCylinder& cylinder, float mass = 1.0f);
 
 	
 

--- a/DrunkEngine/ModuleRenderer3D.cpp
+++ b/DrunkEngine/ModuleRenderer3D.cpp
@@ -131,25 +131,6 @@ update_status ModuleRenderer3D::PreUpdate(float dt)
 	for(uint i = 0; i < MAX_LIGHTS; ++i)
 		lights[i].Render();
 
-	// Test Lines
-	glLineWidth(2.0f);
-
-	glBegin(GL_LINES);
-	{
-		glVertex3f(0.0f, 0.0f, 0.0f);
-		glVertex3f(10.0f, 0.0f, 10.0f);
-
-		glVertex3f(0.0f, 0.0f, 0.0f);
-		glVertex3f(10.0f, 10.0f, 0.0f);
-
-		glVertex3f(0.0f, 0.0f, 0.0f);
-		glVertex3f(0.0f, 10.0f, 10.0f);
-
-	}
-	glEnd();
-
-	glLineWidth(1.0f);
-
 	return UPDATE_CONTINUE;
 }
 

--- a/DrunkEngine/ModuleRenderer3D.cpp
+++ b/DrunkEngine/ModuleRenderer3D.cpp
@@ -134,15 +134,22 @@ update_status ModuleRenderer3D::PreUpdate(float dt)
 	return UPDATE_CONTINUE;
 }
 
-// PostUpdate present buffer to screen
-update_status ModuleRenderer3D::PostUpdate(float dt)
+// Do the render of Objects
+update_status ModuleRenderer3D::Update(float dt)
 {
-	// Render From primitive list?
+	// Render From primitive list
 	std::list<PhysBody3D*>::iterator item_render = App->physics->bodies.begin();
 	while (item_render != App->physics->bodies.end() && App->physics->bodies.size() > 0) {
 		item_render._Ptr->_Myval->mbody->InnerRender();
 		item_render++;
 	}
+
+}
+
+// PostUpdate present buffer to screen
+update_status ModuleRenderer3D::PostUpdate(float dt)
+{
+	
 	
 	SDL_GL_SwapWindow(App->window->window);
 

--- a/DrunkEngine/ModuleRenderer3D.cpp
+++ b/DrunkEngine/ModuleRenderer3D.cpp
@@ -4,6 +4,7 @@
 #include "SDL/include/SDL_opengl.h"
 #include <gl/GL.h>
 #include <gl/GLU.h>
+#include "PhysBody3D.h"
 
 #pragma comment (lib, "glew32.lib")
 #pragma comment (lib, "glu32.lib")    /* link OpenGL Utility lib     */
@@ -130,7 +131,7 @@ update_status ModuleRenderer3D::PreUpdate(float dt)
 	for(uint i = 0; i < MAX_LIGHTS; ++i)
 		lights[i].Render();
 
-	// Test Line
+	// Test Lines
 	glLineWidth(2.0f);
 
 	glBegin(GL_LINES);
@@ -155,6 +156,13 @@ update_status ModuleRenderer3D::PreUpdate(float dt)
 // PostUpdate present buffer to screen
 update_status ModuleRenderer3D::PostUpdate(float dt)
 {
+	// Render From primitive list?
+	std::list<PhysBody3D*>::iterator item_render = App->physics->bodies.begin();
+	while (item_render != App->physics->bodies.end() && App->physics->bodies.size() > 0) {
+		item_render._Ptr->_Myval->mbody->InnerRender();
+		item_render++;
+	}
+	
 	SDL_GL_SwapWindow(App->window->window);
 
 	

--- a/DrunkEngine/ModuleRenderer3D.h
+++ b/DrunkEngine/ModuleRenderer3D.h
@@ -17,6 +17,7 @@ public:
 
 	bool Init();
 	update_status PreUpdate(float dt);
+	update_status Update(float dt);
 	update_status PostUpdate(float dt);
 	bool CleanUp();
 

--- a/DrunkEngine/PhysBody3D.cpp
+++ b/DrunkEngine/PhysBody3D.cpp
@@ -3,7 +3,7 @@
 #include "Bullet/include/btBulletDynamicsCommon.h"
 
 // =================================================
-PhysBody3D::PhysBody3D(btRigidBody* body) : body(body)
+PhysBody3D::PhysBody3D(btRigidBody* body, Primitive* mathbody) : body(body), mbody(mathbody)
 {
 	body->setUserPointer(this);
 }

--- a/DrunkEngine/PhysBody3D.cpp
+++ b/DrunkEngine/PhysBody3D.cpp
@@ -5,7 +5,8 @@
 // =================================================
 PhysBody3D::PhysBody3D(btRigidBody* body, Primitive* mathbody) : body(body), mbody(mathbody)
 {
-	body->setUserPointer(this);
+	if(body != nullptr) // Because we can create non physics 3Dbodies
+		body->setUserPointer(this);
 }
 
 // ---------------------------------------------------------

--- a/DrunkEngine/PhysBody3D.h
+++ b/DrunkEngine/PhysBody3D.h
@@ -3,6 +3,7 @@
 
 #include <list>
 #include "Module.h"
+#include "Primitive.h"
 
 class btRigidBody;
 class Module;
@@ -12,7 +13,7 @@ struct PhysBody3D
 {
 	friend class ModulePhysics3D;
 public:
-	PhysBody3D(btRigidBody* body);
+	PhysBody3D(btRigidBody* body, Primitive* mathbody);
 	~PhysBody3D();
 
 	void Push(float x, float y, float z);
@@ -29,6 +30,7 @@ private:
 public:
 	std::list<Module*> collision_listeners;
 	btRigidBody* body = nullptr;
+	Primitive* mbody = nullptr;
 
 public:
 	//Own Code, new Mechanincs

--- a/DrunkEngine/Primitive.cpp
+++ b/DrunkEngine/Primitive.cpp
@@ -169,67 +169,64 @@ void PCube::InnerRender() const
 
 	glBegin(GL_TRIANGLES);
 	{
-		vec verts[8];
-		MathBody.GetCornerPoints(&verts[0]);
-
 		// Face 1 ADC + ABD == 032 + 013
-		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
-		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
-		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
+		glVertex3f(MathBody->CornerPoint(0).x, MathBody->CornerPoint(0).y, MathBody->CornerPoint(0).z);
+		glVertex3f(MathBody->CornerPoint(3).x, MathBody->CornerPoint(3).y, MathBody->CornerPoint(3).z);
+		glVertex3f(MathBody->CornerPoint(2).x, MathBody->CornerPoint(2).y, MathBody->CornerPoint(2).z);
 	
-		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
-		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
-		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
+		glVertex3f(MathBody->CornerPoint(0).x, MathBody->CornerPoint(0).y, MathBody->CornerPoint(0).z);
+		glVertex3f(MathBody->CornerPoint(1).x, MathBody->CornerPoint(1).y, MathBody->CornerPoint(1).z);
+		glVertex3f(MathBody->CornerPoint(3).x, MathBody->CornerPoint(3).y, MathBody->CornerPoint(3).z);
 		
 		// Face 2 BFH + BHD == 157 + 173
 
-		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
-		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
-		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+		glVertex3f(MathBody->CornerPoint(1).x, MathBody->CornerPoint(1).y, MathBody->CornerPoint(1).z);
+		glVertex3f(MathBody->CornerPoint(5).x, MathBody->CornerPoint(5).y, MathBody->CornerPoint(5).z);
+		glVertex3f(MathBody->CornerPoint(7).x, MathBody->CornerPoint(7).y, MathBody->CornerPoint(7).z);
 
-		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
-		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
-		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
+		glVertex3f(MathBody->CornerPoint(1).x, MathBody->CornerPoint(1).y, MathBody->CornerPoint(1).z);
+		glVertex3f(MathBody->CornerPoint(7).x, MathBody->CornerPoint(7).y, MathBody->CornerPoint(7).z);
+		glVertex3f(MathBody->CornerPoint(3).x, MathBody->CornerPoint(3).y, MathBody->CornerPoint(3).z);
 
 		// Face 3 FEH + EGH == 547 + 467
 
-		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
-		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
-		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+		glVertex3f(MathBody->CornerPoint(5).x, MathBody->CornerPoint(5).y, MathBody->CornerPoint(5).z);
+		glVertex3f(MathBody->CornerPoint(4).x, MathBody->CornerPoint(4).y, MathBody->CornerPoint(4).z);
+		glVertex3f(MathBody->CornerPoint(7).x, MathBody->CornerPoint(7).y, MathBody->CornerPoint(7).z);
 
-		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
-		glVertex3f(MathBody.CornerPoint(6).x, MathBody.CornerPoint(6).y, MathBody.CornerPoint(6).z);
-		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+		glVertex3f(MathBody->CornerPoint(4).x, MathBody->CornerPoint(4).y, MathBody->CornerPoint(4).z);
+		glVertex3f(MathBody->CornerPoint(6).x, MathBody->CornerPoint(6).y, MathBody->CornerPoint(6).z);
+		glVertex3f(MathBody->CornerPoint(7).x, MathBody->CornerPoint(7).y, MathBody->CornerPoint(7).z);
 
 		// Face 4 EAC + ECG == 402 + 426
 
-		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
-		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
-		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
+		glVertex3f(MathBody->CornerPoint(4).x, MathBody->CornerPoint(4).y, MathBody->CornerPoint(4).z);
+		glVertex3f(MathBody->CornerPoint(0).x, MathBody->CornerPoint(0).y, MathBody->CornerPoint(0).z);
+		glVertex3f(MathBody->CornerPoint(2).x, MathBody->CornerPoint(2).y, MathBody->CornerPoint(2).z);
 
-		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
-		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(2).z);
-		glVertex3f(MathBody.CornerPoint(6).x, MathBody.CornerPoint(6).y, MathBody.CornerPoint(6).z);
+		glVertex3f(MathBody->CornerPoint(4).x, MathBody->CornerPoint(4).y, MathBody->CornerPoint(4).z);
+		glVertex3f(MathBody->CornerPoint(2).x, MathBody->CornerPoint(3).y, MathBody->CornerPoint(2).z);
+		glVertex3f(MathBody->CornerPoint(6).x, MathBody->CornerPoint(6).y, MathBody->CornerPoint(6).z);
 
 		// Face 5 CDH + CHG == 237 + 276
 
-		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
-		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
-		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+		glVertex3f(MathBody->CornerPoint(2).x, MathBody->CornerPoint(2).y, MathBody->CornerPoint(2).z);
+		glVertex3f(MathBody->CornerPoint(3).x, MathBody->CornerPoint(3).y, MathBody->CornerPoint(3).z);
+		glVertex3f(MathBody->CornerPoint(7).x, MathBody->CornerPoint(7).y, MathBody->CornerPoint(7).z);
 
-		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
-		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
-		glVertex3f(MathBody.CornerPoint(6).x, MathBody.CornerPoint(6).y, MathBody.CornerPoint(6).z);
+		glVertex3f(MathBody->CornerPoint(2).x, MathBody->CornerPoint(2).y, MathBody->CornerPoint(2).z);
+		glVertex3f(MathBody->CornerPoint(7).x, MathBody->CornerPoint(7).y, MathBody->CornerPoint(7).z);
+		glVertex3f(MathBody->CornerPoint(6).x, MathBody->CornerPoint(6).y, MathBody->CornerPoint(6).z);
 
 		// Face 6 AEF + AFB == 045 + 051
 
-		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
-		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
-		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
+		glVertex3f(MathBody->CornerPoint(0).x, MathBody->CornerPoint(0).y, MathBody->CornerPoint(0).z);
+		glVertex3f(MathBody->CornerPoint(4).x, MathBody->CornerPoint(4).y, MathBody->CornerPoint(4).z);
+		glVertex3f(MathBody->CornerPoint(5).x, MathBody->CornerPoint(5).y, MathBody->CornerPoint(5).z);
 
-		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
-		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
-		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
+		glVertex3f(MathBody->CornerPoint(0).x, MathBody->CornerPoint(0).y, MathBody->CornerPoint(0).z);
+		glVertex3f(MathBody->CornerPoint(5).x, MathBody->CornerPoint(5).y, MathBody->CornerPoint(5).z);
+		glVertex3f(MathBody->CornerPoint(1).x, MathBody->CornerPoint(1).y, MathBody->CornerPoint(1).z);
 	}
 
 	// 
@@ -361,10 +358,10 @@ void PPlane::InnerRender() const
 bool PLine::Intersects(Primitive* mbody2)
 {
 	switch (mbody2->GetType()) {
-		case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-		case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-		case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-		case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+		case 2: return ((PPlane*)mbody2)->MathBody->Intersects(*MathBody);
+		case 3: return ((PCube*)mbody2)->MathBody->Intersects(*MathBody);
+		case 4: return ((PSphere*)mbody2)->MathBody->Intersects(*MathBody);
+		case 5: return ((PCylinder*)mbody2)->MathBody->Intersects(*MathBody);
 		default: return false;
 	}
 
@@ -374,10 +371,10 @@ bool PLine::Intersects(Primitive* mbody2)
 bool PPlane::Intersects(Primitive* mbody2)
 {
 	switch (mbody2->GetType()) {
-	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	case 2: return ((PPlane*)mbody2)->MathBody->Intersects(*MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody->Intersects(*MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody->Intersects(*MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody->Intersects(*MathBody);
 	default: return false;
 	}
 
@@ -387,10 +384,10 @@ bool PPlane::Intersects(Primitive* mbody2)
 bool PCube::Intersects(Primitive* mbody2)
 {
 	switch (mbody2->GetType()) {
-	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	case 2: return ((PPlane*)mbody2)->MathBody->Intersects(*MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody->Intersects(*MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody->Intersects(*MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody->Intersects(*MathBody);
 	default: return false;
 	}
 
@@ -400,10 +397,10 @@ bool PCube::Intersects(Primitive* mbody2)
 bool PSphere::Intersects(Primitive* mbody2)
 {
 	switch (mbody2->GetType()) {
-	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	case 2: return ((PPlane*)mbody2)->MathBody->Intersects(*MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody->Intersects(*MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody->Intersects(*MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody->Intersects(*MathBody);
 	default: return false;
 	}
 
@@ -413,11 +410,10 @@ bool PSphere::Intersects(Primitive* mbody2)
 bool PCylinder::Intersects(Primitive* mbody2)
 {
 	switch (mbody2->GetType()) {
-	case 1: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
-	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	case 2: return ((PPlane*)mbody2)->MathBody->Intersects(*MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody->Intersects(*MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody->Intersects(*MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody->Intersects(*MathBody);
 	default: return false;
 	}
 

--- a/DrunkEngine/Primitive.cpp
+++ b/DrunkEngine/Primitive.cpp
@@ -169,7 +169,9 @@ void PCube::InnerRender() const
 
 	glBegin(GL_TRIANGLES);
 	{
-	
+		vec verts[8];
+		MathBody.GetCornerPoints(&verts[0]);
+
 		// Face 1 ADC + ABD == 032 + 013
 		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
 		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);

--- a/DrunkEngine/Primitive.cpp
+++ b/DrunkEngine/Primitive.cpp
@@ -111,50 +111,126 @@ PCube::PCube(float sizeX, float sizeY, float sizeZ) : Primitive(), size(sizeX, s
 {
 	type = PrimitiveTypes::Primitive_Cube;
 }
+PCube::PCube(float size_cube) : Primitive(), size(size_cube, size_cube, size_cube)
+{
+	type = PrimitiveTypes::Primitive_Cube;
+}
 
 void PCube::InnerRender() const
-{	
+{
+	// Direct with random shiet i do not know what is
+	/*
 	float sx = size.x * 0.5f;
 	float sy = size.y * 0.5f;
 	float sz = size.z * 0.5f;
 
+	// GL_QUAD APPROACH
 	glBegin(GL_QUADS);
+	{
+		glNormal3f(0.0f, 0.0f, 1.0f);
+		glVertex3f(-sx, -sy, sz);
+		glVertex3f(sx, -sy, sz);
+		glVertex3f(sx, sy, sz);
+		glVertex3f(-sx, sy, sz);
 
-	glNormal3f(0.0f, 0.0f, 1.0f);
-	glVertex3f(-sx, -sy, sz);
-	glVertex3f( sx, -sy, sz);
-	glVertex3f( sx,  sy, sz);
-	glVertex3f(-sx,  sy, sz);
+		glNormal3f(0.0f, 0.0f, -1.0f);
+		glVertex3f(sx, -sy, -sz);
+		glVertex3f(-sx, -sy, -sz);
+		glVertex3f(-sx, sy, -sz);
+		glVertex3f(sx, sy, -sz);
 
-	glNormal3f(0.0f, 0.0f, -1.0f);
-	glVertex3f( sx, -sy, -sz);
-	glVertex3f(-sx, -sy, -sz);
-	glVertex3f(-sx,  sy, -sz);
-	glVertex3f( sx,  sy, -sz);
+		glNormal3f(1.0f, 0.0f, 0.0f);
+		glVertex3f(sx, -sy, sz);
+		glVertex3f(sx, -sy, -sz);
+		glVertex3f(sx, sy, -sz);
+		glVertex3f(sx, sy, sz);
 
-	glNormal3f(1.0f, 0.0f, 0.0f);
-	glVertex3f(sx, -sy,  sz);
-	glVertex3f(sx, -sy, -sz);
-	glVertex3f(sx,  sy, -sz);
-	glVertex3f(sx,  sy,  sz);
+		glNormal3f(-1.0f, 0.0f, 0.0f);
+		glVertex3f(-sx, -sy, -sz);
+		glVertex3f(-sx, -sy, sz);
+		glVertex3f(-sx, sy, sz);
+		glVertex3f(-sx, sy, -sz);
 
-	glNormal3f(-1.0f, 0.0f, 0.0f);
-	glVertex3f(-sx, -sy, -sz);
-	glVertex3f(-sx, -sy,  sz);
-	glVertex3f(-sx,  sy,  sz);
-	glVertex3f(-sx,  sy, -sz);
+		glNormal3f(0.0f, 1.0f, 0.0f);
+		glVertex3f(-sx, sy, sz);
+		glVertex3f(sx, sy, sz);
+		glVertex3f(sx, sy, -sz);
+		glVertex3f(-sx, sy, -sz);
 
-	glNormal3f(0.0f, 1.0f, 0.0f);
-	glVertex3f(-sx, sy,  sz);
-	glVertex3f( sx, sy,  sz);
-	glVertex3f( sx, sy, -sz);
-	glVertex3f(-sx, sy, -sz);
+		glNormal3f(0.0f, -1.0f, 0.0f);
+		glVertex3f(-sx, -sy, -sz);
+		glVertex3f(sx, -sy, -sz);
+		glVertex3f(sx, -sy, sz);
+		glVertex3f(-sx, -sy, sz);
+	}
+	*/	
 
-	glNormal3f(0.0f, -1.0f, 0.0f);
-	glVertex3f(-sx, -sy, -sz);
-	glVertex3f( sx, -sy, -sz);
-	glVertex3f( sx, -sy,  sz);
-	glVertex3f(-sx, -sy,  sz);
+	// From MGL to Cube with GL_Triangles
+
+	glBegin(GL_TRIANGLES);
+	{
+	
+		// Face 1 ADC + ABD == 032 + 013
+		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
+		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
+		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
+	
+		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
+		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
+		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
+		
+		// Face 2 BFH + BHD == 157 + 173
+
+		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
+		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
+		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+
+		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
+		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
+
+		// Face 3 FEH + EGH == 547 + 467
+
+		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
+		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
+		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+
+		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
+		glVertex3f(MathBody.CornerPoint(6).x, MathBody.CornerPoint(6).y, MathBody.CornerPoint(6).z);
+		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+
+		// Face 4 EAC + ECG == 402 + 426
+
+		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
+		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
+		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
+
+		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
+		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(2).z);
+		glVertex3f(MathBody.CornerPoint(6).x, MathBody.CornerPoint(6).y, MathBody.CornerPoint(6).z);
+
+		// Face 5 CDH + CHG == 237 + 276
+
+		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
+		glVertex3f(MathBody.CornerPoint(3).x, MathBody.CornerPoint(3).y, MathBody.CornerPoint(3).z);
+		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+
+		glVertex3f(MathBody.CornerPoint(2).x, MathBody.CornerPoint(2).y, MathBody.CornerPoint(2).z);
+		glVertex3f(MathBody.CornerPoint(7).x, MathBody.CornerPoint(7).y, MathBody.CornerPoint(7).z);
+		glVertex3f(MathBody.CornerPoint(6).x, MathBody.CornerPoint(6).y, MathBody.CornerPoint(6).z);
+
+		// Face 6 AEF + AFB == 045 + 051
+
+		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
+		glVertex3f(MathBody.CornerPoint(4).x, MathBody.CornerPoint(4).y, MathBody.CornerPoint(4).z);
+		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
+
+		glVertex3f(MathBody.CornerPoint(0).x, MathBody.CornerPoint(0).y, MathBody.CornerPoint(0).z);
+		glVertex3f(MathBody.CornerPoint(5).x, MathBody.CornerPoint(5).y, MathBody.CornerPoint(5).z);
+		glVertex3f(MathBody.CornerPoint(1).x, MathBody.CornerPoint(1).y, MathBody.CornerPoint(1).z);
+	}
+
+	// 
 
 	glEnd();
 }
@@ -282,11 +358,11 @@ void PPlane::InnerRender() const
 
 bool PLine::Intersects(Primitive* mbody2)
 {
-	switch (type) {
-		case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-		case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-		case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-		case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	switch (mbody2->GetType()) {
+		case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+		case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+		case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+		case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
 		default: return false;
 	}
 
@@ -295,11 +371,11 @@ bool PLine::Intersects(Primitive* mbody2)
 
 bool PPlane::Intersects(Primitive* mbody2)
 {
-	switch (type) {
-	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	switch (mbody2->GetType()) {
+	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
 	default: return false;
 	}
 
@@ -308,12 +384,11 @@ bool PPlane::Intersects(Primitive* mbody2)
 
 bool PCube::Intersects(Primitive* mbody2)
 {
-	switch (type) {
-	case 2: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
-	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	switch (mbody2->GetType()) {
+	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
 	default: return false;
 	}
 
@@ -322,12 +397,11 @@ bool PCube::Intersects(Primitive* mbody2)
 
 bool PSphere::Intersects(Primitive* mbody2)
 {
-	switch (type) {
-	case 2: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
-	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	switch (mbody2->GetType()) {
+	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
 	default: return false;
 	}
 
@@ -336,12 +410,12 @@ bool PSphere::Intersects(Primitive* mbody2)
 
 bool PCylinder::Intersects(Primitive* mbody2)
 {
-	switch (type) {
-	case 2: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
-	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
-	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
-	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
-	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	switch (mbody2->GetType()) {
+	case 1: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
+	case 2: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 3: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
 	default: return false;
 	}
 

--- a/DrunkEngine/Primitive.cpp
+++ b/DrunkEngine/Primitive.cpp
@@ -279,3 +279,71 @@ void PPlane::InnerRender() const
 
 	glEnd();
 }
+
+bool PLine::Intersects(Primitive* mbody2)
+{
+	switch (type) {
+		case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+		case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+		case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+		case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+		default: return false;
+	}
+
+	return false;
+}
+
+bool PPlane::Intersects(Primitive* mbody2)
+{
+	switch (type) {
+	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	default: return false;
+	}
+
+	return false;
+}
+
+bool PCube::Intersects(Primitive* mbody2)
+{
+	switch (type) {
+	case 2: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
+	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	default: return false;
+	}
+
+	return false;
+}
+
+bool PSphere::Intersects(Primitive* mbody2)
+{
+	switch (type) {
+	case 2: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
+	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	default: return false;
+	}
+
+	return false;
+}
+
+bool PCylinder::Intersects(Primitive* mbody2)
+{
+	switch (type) {
+	case 2: return ((PLine*)mbody2)->MathBody.Intersects(MathBody);
+	case 3: return ((PPlane*)mbody2)->MathBody.Intersects(MathBody);
+	case 4: return ((PCube*)mbody2)->MathBody.Intersects(MathBody);
+	case 5: return ((PSphere*)mbody2)->MathBody.Intersects(MathBody);
+	case 6: return ((PCylinder*)mbody2)->MathBody.Intersects(MathBody);
+	default: return false;
+	}
+
+	return false;
+}

--- a/DrunkEngine/Primitive.h
+++ b/DrunkEngine/Primitive.h
@@ -31,6 +31,8 @@ public:
 	void			Scale(float x, float y, float z);
 	PrimitiveTypes	GetType() const;
 
+	virtual bool Intersects(Primitive* mbody2) { return false;};
+
 public:
 	
 	Color color;
@@ -48,6 +50,8 @@ public :
 	PCube();
 	PCube(float sizeX, float sizeY, float sizeZ);
 	void InnerRender() const;
+	bool Intersects(Primitive* mbody2);
+
 public:
 	vec size;
 	Polyhedron MathBody;
@@ -60,6 +64,8 @@ public:
 	PSphere();
 	PSphere(float radius);
 	void InnerRender() const;
+	bool Intersects(Primitive* mbody2);
+
 public:
 	float radius;
 	Sphere MathBody;
@@ -72,6 +78,8 @@ public:
 	PCylinder();
 	PCylinder(float radius, float height);
 	void InnerRender() const;
+	bool Intersects(Primitive* mbody2);
+
 public:
 	float radius;
 	float height;
@@ -85,6 +93,8 @@ public:
 	PLine();
 	PLine(float x, float y, float z);
 	void InnerRender() const;
+	bool Intersects(Primitive* mbody2);
+
 public:
 	vec origin;
 	vec destination;
@@ -98,6 +108,8 @@ public:
 	PPlane();
 	PPlane(float x, float y, float z, float d);
 	void InnerRender() const;
+	bool Intersects(Primitive* mbody2);
+
 public:
 	vec normal;
 	float constant;

--- a/DrunkEngine/Primitive.h
+++ b/DrunkEngine/Primitive.h
@@ -55,7 +55,7 @@ public :
 
 public:
 	vec size;
-	AABB MathBody;
+	AABB* MathBody;
 };
 
 // ============================================
@@ -69,7 +69,7 @@ public:
 
 public:
 	float radius;
-	Sphere MathBody;
+	Sphere* MathBody;
 };
 
 // ============================================
@@ -84,7 +84,7 @@ public:
 public:
 	float radius;
 	float height;
-	Capsule MathBody;
+	Capsule* MathBody;
 };
 
 // ============================================
@@ -99,7 +99,7 @@ public:
 public:
 	vec origin;
 	vec destination;
-	Line MathBody;
+	Line* MathBody;
 };
 
 // ============================================
@@ -114,7 +114,7 @@ public:
 public:
 	vec normal;
 	float constant;
-	Plane MathBody;
+	Plane* MathBody;
 };
 
 #endif // !_PRIMITIVE_H_

--- a/DrunkEngine/Primitive.h
+++ b/DrunkEngine/Primitive.h
@@ -49,12 +49,13 @@ class PCube : public Primitive
 public :
 	PCube();
 	PCube(float sizeX, float sizeY, float sizeZ);
+	PCube(float size_cube);
 	void InnerRender() const;
 	bool Intersects(Primitive* mbody2);
 
 public:
 	vec size;
-	Polyhedron MathBody;
+	AABB MathBody;
 };
 
 // ============================================


### PR DESCRIPTION
Collision detection through mathgeolib (between mathobjects)

Can't update properly the position of mathobj with their respective physobj, still render for cube through triangles works as intended.